### PR TITLE
updated api controller to set proper input dates

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,16 +1,19 @@
 class ApiController < ApplicationController
-  before_action :set_params, only: [:hours]
+  before_action :set_params
 
   def hours
-    dates = @dates.nil? ? Date.today : @dates
-
-    alma = Alma.new(day, day)
-    hours = Api::HoursXmlToJsonParser.call(alma.xml_document)
+    dates = @dates.blank? ? [Date.today, Date.today] : @dates.sort
+    alma = Alma.new(dates.first, dates.last)
+    hours = API::HoursXmlToJsonParser.call(alma.xml_document)
 
     render json: hours
   end
 
+  private
+
   def set_params
+    # expecting a JSON array of dates, see following example:
+    # {"dates":["2016-01-01","2016-01-02","2016-01-03"]}
     @dates = params[:dates]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
-  get "/hours(/:dates)", to: "Api#hours", as: "hours"
+  post '/hours', :to => 'api#hours', :as => 'api_hours'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -5,7 +5,7 @@ describe ApiController, type: :controller do
     let(:day) { }
     let(:api) { double("API") }
     let(:service) { double("API::HoursXmlToJsonParser") }
-    let(:valid_json) { JSON.parse({ valid_json_with_data: {data: "data"} }) }
+    let(:valid_json) { JSON.parse('{ "valid_json_with_data": {"data": "data"} }') }
     let(:valid_xml) { "<days><day><date>2018-06-03Z</date><from>00:00</from><to>23:59</to></day></days>" }
 
     context "When no day is provided" do
@@ -35,7 +35,7 @@ describe ApiController, type: :controller do
     let(:day) { }
     let(:api) { double("API") }
     let(:service) { double("API::HoursXmlToJsonParser") }
-    let(:valid_json) { JSON.parse({ valid_json_with_data: {data: "data"} }) }
+    let(:valid_json) { JSON.parse('{ "valid_json_with_data": {"data": "data"} }') }
     let(:valid_xml) { "<days><day><date>2018-06-03Z</date><from>00:00</from><to>23:59</to></day><day><date>2018-06-04Z</date><from>01:00</from><to>21:59</to></day></days>" }
 
     context "When a day is provided" do


### PR DESCRIPTION
Given `{"dates":["2018-04-03","2018-04-04"]}` for `/hours`
We get:
```
{
  "2018-04-03T00:00:00+00:00": {
    "open": "00:00",
    "close": "23:59",
    "string_date": "Tue, Apr 3, 2018",
    "sortable_date": "2018-04-03",
    "formatted_hours": "Open 24 Hours",
    "open_all_day": true,
    "closes_at_night": false
  },
  "2018-04-04T00:00:00+00:00": {
    "open": "00:00",
    "close": "23:59",
    "string_date": "Wed, Apr 4, 2018",
    "sortable_date": "2018-04-04",
    "formatted_hours": "Open 24 Hours",
    "open_all_day": true,
    "closes_at_night": false
  }
}
```

Given `{"dates":[]}` (it now defaults to today), so we get:

```
{
"2018-06-18T00:00:00+00:00": {
    "open": "07:30",
    "close": "21:00",
    "string_date": "Mon, Jun 18, 2018",
    "sortable_date": "2018-06-18",
    "formatted_hours": "07:30 - 21:00",
    "open_all_day": false,
    "closes_at_night": true
  }
}
```