### PR TITLE
added widgets controller

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -1,0 +1,24 @@
+class WidgetsController < ApplicationController
+  include ActionController::MimeResponds
+
+  def show
+    dates = [Date.today, Date.today + 6.days]
+    alma = Alma.new(dates.first, dates.last)
+    @hours = API::HoursXmlToJsonParser.call(alma.xml_document)
+
+    respond_to do |format|
+      format.js   { render js: js_constructor }
+    end
+  end
+
+  private
+
+  def js_constructor
+    content = ActionController::Base.new.render_to_string("widgets/#{params[:template]}",
+                                                          layout: false,
+                                                          :locals => {
+                                                              :hours => JSON.parse(@hours)
+                                                          })
+    "document.write(#{content.to_json})"
+  end
+end

--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -2,7 +2,7 @@ class WidgetsController < ApplicationController
   include ActionController::MimeResponds
 
   def show
-    dates = [Date.today, Date.today + 6.days]
+    dates = [Date.today.strftime("%Y-%m-%d"), (Date.today+6.days).strftime("%Y-%m-%d")]
     alma = Alma.new(dates.first, dates.last)
     @hours = API::HoursXmlToJsonParser.call(alma.xml_document)
 

--- a/app/views/widgets/this_weeks_hours.html.erb
+++ b/app/views/widgets/this_weeks_hours.html.erb
@@ -1,0 +1,9 @@
+<h1>This Week's Hours</h1>
+
+<p>
+  <% hours.each do |key, value| %>
+    <% day = Date.parse(key) %>
+    <b><%= day.today? ? 'Today' : day.strftime("%A") %>:</b>
+    <%= "#{value["formatted_hours"]}" %><br>
+  <% end %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   post '/hours', :to => 'api#hours', :as => 'api_hours'
+  get '/widgets/:template', :to => 'widgets#show'
 end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe WidgetsController, type: :controller do
+  describe "#show" do
+    let(:day) { }
+    let(:valid_json) { JSON.parse('{ "valid_json_with_data": {"data": "data"} }') }
+    let(:valid_xml) { "<days><day><date>2018-06-03Z</date><from>00:00</from><to>23:59</to></day></days>" }
+    let(:alma) { Alma.new(date_from, date_to) }
+    let(:url) { "#{ENV['ALMA_OPEN_HOURS_URL']}?apikey=#{ENV['ALMA_API_KEY']}&from=#{date_from}&to=#{date_to}" }
+    let(:xml) { File.read("spec/fixtures/alma_open_hours.xml") }
+    let(:date_from) { "2018-06-18" }
+    let(:date_to) { "2018-06-18" }
+    let(:cached_minutes) { "1" }
+
+    before do
+      ENV['ALMA_OPEN_HOURS_URL'] = 'https://url/to/alma/api'
+      ENV['ALMA_API_KEY'] = 'almaapikey123'
+      ENV['ALMA_CACHED_FOR'] = '720'
+
+      stub_request(:get, "https://url/to/alma/api?apikey=almaapikey123&from=2018-06-20&to=2018-06-26").
+          with(
+              headers: {
+                  'Accept'=>'*/*',
+                  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                  'User-Agent'=>'Ruby'
+              }).
+          to_return(status: 200, body: "", headers: {})
+
+      # stub_request(:get, url).
+      #   with(
+      #       headers: {
+      #           'Accept'=>'*/*',
+      #           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      #           'User-Agent'=>'Ruby'
+      #       }).
+      #   to_return(status: 200, body: xml, headers: {})
+    end
+
+    context "When this week's hours widget is returned" do
+      before do
+        allow(API::HoursXmlToJsonParser).to receive(:call).with(anything()).and_return(valid_json)
+        allow(alma).to receive(:xml_document).and_return(valid_xml)
+      end
+
+      it "responds to js" do
+        get :show, params: { template: 'this_weeks_hours' }
+        # expect(assigns(:hours)["valid_json_with_data"]["data"]).to eq "data"
+      end
+    end
+  end
+end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -1,50 +1,33 @@
 require 'rails_helper'
 
-describe WidgetsController, type: :controller do
-  describe "#show" do
+RSpec.describe WidgetsController, type: :controller do
+  describe "GET #show" do
     let(:day) { }
-    let(:valid_json) { JSON.parse('{ "valid_json_with_data": {"data": "data"} }') }
+    let(:valid_json) { File.read("spec/fixtures/alma_open_hours.json") }
     let(:valid_xml) { "<days><day><date>2018-06-03Z</date><from>00:00</from><to>23:59</to></day></days>" }
-    let(:alma) { Alma.new(date_from, date_to) }
     let(:url) { "#{ENV['ALMA_OPEN_HOURS_URL']}?apikey=#{ENV['ALMA_API_KEY']}&from=#{date_from}&to=#{date_to}" }
     let(:xml) { File.read("spec/fixtures/alma_open_hours.xml") }
-    let(:date_from) { "2018-06-18" }
-    let(:date_to) { "2018-06-18" }
+    let(:date_from) { "2018-06-03" }
+    let(:date_to) { "2018-06-09" }
     let(:cached_minutes) { "1" }
 
     before do
       ENV['ALMA_OPEN_HOURS_URL'] = 'https://url/to/alma/api'
       ENV['ALMA_API_KEY'] = 'almaapikey123'
       ENV['ALMA_CACHED_FOR'] = '720'
-
-      stub_request(:get, "https://url/to/alma/api?apikey=almaapikey123&from=2018-06-20&to=2018-06-26").
-          with(
-              headers: {
-                  'Accept'=>'*/*',
-                  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-                  'User-Agent'=>'Ruby'
-              }).
-          to_return(status: 200, body: "", headers: {})
-
-      # stub_request(:get, url).
-      #   with(
-      #       headers: {
-      #           'Accept'=>'*/*',
-      #           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      #           'User-Agent'=>'Ruby'
-      #       }).
-      #   to_return(status: 200, body: xml, headers: {})
     end
 
     context "When this week's hours widget is returned" do
       before do
-        allow(API::HoursXmlToJsonParser).to receive(:call).with(anything()).and_return(valid_json)
-        allow(alma).to receive(:xml_document).and_return(valid_xml)
+        allow(API::HoursXmlToJsonParser).to receive(:call).with(valid_xml).and_return(valid_json)
+        allow_any_instance_of(Alma).to receive(:xml_document).and_return(valid_xml)
+        allow_any_instance_of(Alma).to receive(:fetch).and_return(valid_xml)
       end
 
       it "responds to js" do
-        get :show, params: { template: 'this_weeks_hours' }
-        # expect(assigns(:hours)["valid_json_with_data"]["data"]).to eq "data"
+        get :show, params: { template: 'this_weeks_hours', format: :js }
+        expect(assigns(:hours)).to include("2018-06-03")
+        expect(assigns(:hours)).to include("2018-06-09")
       end
     end
   end

--- a/spec/fixtures/alma_open_hours.json
+++ b/spec/fixtures/alma_open_hours.json
@@ -1,0 +1,65 @@
+{
+  "2018-06-03T00:00:00+00:00": {
+    "open": "13:00",
+    "close": "23:59",
+    "string_date": "Sun, Jun 3, 2018",
+    "sortable_date": "2018-06-03",
+    "formatted_hours": "13:00 - 23:59",
+    "open_all_day": false,
+    "closes_at_night": false
+  },
+  "2018-06-04T00:00:00+00:00": {
+    "open": "00:00",
+    "close": "23:59",
+    "string_date": "Mon, Jun 4, 2018",
+    "sortable_date": "2018-06-04",
+    "formatted_hours": "Open 24 Hours",
+    "open_all_day": true,
+    "closes_at_night": false
+  },
+  "2018-06-05T00:00:00+00:00": {
+    "open": "00:00",
+    "close": "23:59",
+    "string_date": "Tue, Jun 5, 2018",
+    "sortable_date": "2018-06-05",
+    "formatted_hours": "Open 24 Hours",
+    "open_all_day": true,
+    "closes_at_night": false
+  },
+  "2018-06-06T00:00:00+00:00": {
+    "open": "00:00",
+    "close": "23:59",
+    "string_date": "Wed, Jun 6, 2018",
+    "sortable_date": "2018-06-06",
+    "formatted_hours": "Open 24 Hours",
+    "open_all_day": true,
+    "closes_at_night": false
+  },
+  "2018-06-07T00:00:00+00:00": {
+    "open": "00:00",
+    "close": "23:59",
+    "string_date": "Thu, Jun 7, 2018",
+    "sortable_date": "2018-06-07",
+    "formatted_hours": "Open 24 Hours",
+    "open_all_day": true,
+    "closes_at_night": false
+  },
+  "2018-06-08T00:00:00+00:00": {
+    "open": "00:00",
+    "close": "02:59",
+    "string_date": "Fri, Jun 8, 2018",
+    "sortable_date": "2018-06-08",
+    "formatted_hours": "00:00 - 02:59",
+    "open_all_day": false,
+    "closes_at_night": true
+  },
+  "2018-06-09T00:00:00+00:00": {
+    "open": "10:00",
+    "close": "23:59",
+    "string_date": "Sat, Jun 9, 2018",
+    "sortable_date": "2018-06-09",
+    "formatted_hours": "10:00 - 23:59",
+    "open_all_day": false,
+    "closes_at_night": false
+  }
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'webmock/rspec'
+require 'rails-controller-testing'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -58,4 +59,10 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  [:controller, :view, :request].each do |type|
+    config.include ::Rails::Controller::Testing::TestProcess, :type => type
+    config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
+    config.include ::Rails::Controller::Testing::Integration, :type => type
+  end
 end


### PR DESCRIPTION
fixes #25 

Usage: In a Drupal block or theme template, we could now include a reference to a widget (i.e. `widgets/this_weeks_hours.js`):
```
<script type="text/javascript" src="http://localhost:3000/widgets/this_weeks_hours.js"></script>
```

Preview in a Drupal 7 instance:
![image](https://user-images.githubusercontent.com/3486120/41677647-bf30f02a-747d-11e8-9735-b4536a480074.png)
