### PR TITLE
Feature/smarter parsing

### DIFF
--- a/app/services/api/hours_xml_to_json_parser.rb
+++ b/app/services/api/hours_xml_to_json_parser.rb
@@ -14,8 +14,11 @@ module API
       json_data = {}
       parsed_xml = xml_parser.parse(hours_xml)
       day_list = parsed_xml.xpath("//day")
-      day_list.each_with_index do |day, i|
-        data = {open_time: day.xpath("//from")[i].text.to_s, close_time: day.xpath("//to")[i].text.to_s, parsed_time: day.xpath("//date")[i].text.gsub("Z", "") }
+      hour_list = parsed_xml.xpath("//hour").map { |element| element.element_children.map(&:text) } 
+      day_list.each do |day, i|
+        data = {open_time: hour_list.empty? ? '00:00' : hour_list[i].first.to_s, 
+                close_time: hour_list.empty? ? '00:00' : hour_list[i].second.text.to_s, 
+                parsed_time: day.xpath("//date")[i].text.gsub("Z", "") }
         json_data[DateTime.parse(data[:parsed_time]).to_s] = build_json_from_data(data)
       end
       json_data.to_json
@@ -47,7 +50,7 @@ module API
         "Closes at #{close_time}"
       elsif (open_time == "00:00" && close_time == "23:59")
         "Open 24 Hours"
-      elsif (open_time == "01:00" && close_time == "01:00")
+      elsif ((open_time == "01:00" && close_time == "01:00") || (open_time == "00:00" && close_time == "00:00" ))
         "Closed"
       else
         "#{Time.parse(open_time).strftime("%l:%M%P")} -#{Time.parse(close_time).strftime("%l:%M%P")}"

--- a/app/services/api/hours_xml_to_json_parser.rb
+++ b/app/services/api/hours_xml_to_json_parser.rb
@@ -22,8 +22,8 @@ module API
     end
 
     def self.build_json_from_data(data)
-      { open: data[:open_time],
-        close: data[:close_time],
+      { open: Time.parse(data[:open_time]).strftime("%l:%M%P"),
+        close: Time.parse(data[:close_time]).strftime("%l:%M%P"),
         string_date: DateTime.parse(data[:parsed_time].to_s).strftime("%a, %b %e, %Y"),
         sortable_date: data[:parsed_time].to_s,
         formatted_hours: formatted_hours(data[:open_time], data[:close_time]),
@@ -42,7 +42,7 @@ module API
 
     def self.formatted_hours(open_time, close_time)
       if (close_time == "00:14")
-        "#{open_time} - No Closing"
+        "#{Time.parse(open_time).strftime("%l:%M%P")} - No Closing"
       elsif (open_time == "00:14")
         "Closes at #{close_time}"
       elsif (open_time == "00:00" && close_time == "23:59")
@@ -50,7 +50,7 @@ module API
       elsif (open_time == "01:00" && close_time == "01:00")
         "Closed"
       else
-        "#{open_time} - #{close_time}"
+        "#{Time.parse(open_time).strftime("%l:%M%P")} -#{Time.parse(close_time).strftime("%l:%M%P")}"
       end
     end
 

--- a/app/services/api/hours_xml_to_json_parser.rb
+++ b/app/services/api/hours_xml_to_json_parser.rb
@@ -15,9 +15,9 @@ module API
       parsed_xml = xml_parser.parse(hours_xml)
       day_list = parsed_xml.xpath("//day")
       hour_list = parsed_xml.xpath("//hour").map { |element| element.element_children.map(&:text) } 
-      day_list.each do |day, i|
+      day_list.each_with_index do |day, i|
         data = {open_time: hour_list[i].empty? ? '00:00' : hour_list[i].first.to_s, 
-                close_time: hour_list[i].empty? ? '00:00' : hour_list[i].second.text.to_s, 
+                close_time: hour_list[i].empty? ? '00:00' : hour_list[i].second.to_s, 
                 parsed_time: day.xpath("//date")[i].text.gsub("Z", "") }
         json_data[DateTime.parse(data[:parsed_time]).to_s] = build_json_from_data(data)
       end

--- a/app/services/api/hours_xml_to_json_parser.rb
+++ b/app/services/api/hours_xml_to_json_parser.rb
@@ -16,8 +16,8 @@ module API
       day_list = parsed_xml.xpath("//day")
       hour_list = parsed_xml.xpath("//hour").map { |element| element.element_children.map(&:text) } 
       day_list.each do |day, i|
-        data = {open_time: hour_list.empty? ? '00:00' : hour_list[i].first.to_s, 
-                close_time: hour_list.empty? ? '00:00' : hour_list[i].second.text.to_s, 
+        data = {open_time: hour_list[i].empty? ? '00:00' : hour_list[i].first.to_s, 
+                close_time: hour_list[i].empty? ? '00:00' : hour_list[i].second.text.to_s, 
                 parsed_time: day.xpath("//date")[i].text.gsub("Z", "") }
         json_data[DateTime.parse(data[:parsed_time]).to_s] = build_json_from_data(data)
       end

--- a/spec/services/api/hours_to_xml_parser_spec.rb
+++ b/spec/services/api/hours_to_xml_parser_spec.rb
@@ -23,11 +23,11 @@ describe API::HoursXmlToJsonParser do
         </days>'
       }
       it "outputs JSON in a valid format" do
-        expect(JSON.parse(service.call(xml))[formatted_time]["open"]).to eq "00:00"
-        expect(JSON.parse(service.call(xml))[formatted_time]["close"]).to eq "02:59"
+        expect(JSON.parse(service.call(xml))[formatted_time]["open"]).to eq "12:00am"
+        expect(JSON.parse(service.call(xml))[formatted_time]["close"]).to eq " 2:59am"
         expect(JSON.parse(service.call(xml))[formatted_time]["string_date"]).to eq "Fri, Jun  8, 2018"
         expect(JSON.parse(service.call(xml))[formatted_time]["sortable_date"]).to eq "2018-06-08"
-        expect(JSON.parse(service.call(xml))[formatted_time]["formatted_hours"]).to eq "00:00 - 02:59"
+        expect(JSON.parse(service.call(xml))[formatted_time]["formatted_hours"]).to eq "12:00am - 2:59am"
         expect(JSON.parse(service.call(xml))[formatted_time]["open_all_day"]).to eq false
         expect(JSON.parse(service.call(xml))[formatted_time]["closes_at_night"]).to eq true
       end
@@ -59,11 +59,11 @@ describe API::HoursXmlToJsonParser do
         </days>'
       }
       it "outputs JSON in a valid format" do
-        expect(JSON.parse(service.call(xml))[formatted_time]["open"]).to eq "00:00"
-        expect(JSON.parse(service.call(xml))[formatted_time]["close"]).to eq "02:59"
+        expect(JSON.parse(service.call(xml))[formatted_time]["open"]).to eq "12:00am"
+        expect(JSON.parse(service.call(xml))[formatted_time]["close"]).to eq " 2:59am"
         expect(JSON.parse(service.call(xml))[formatted_time]["string_date"]).to eq "Fri, Jun  8, 2018"
         expect(JSON.parse(service.call(xml))[formatted_time]["sortable_date"]).to eq "2018-06-08"
-        expect(JSON.parse(service.call(xml))[formatted_time]["formatted_hours"]).to eq "00:00 - 02:59"
+        expect(JSON.parse(service.call(xml))[formatted_time]["formatted_hours"]).to eq "12:00am - 2:59am"
         expect(JSON.parse(service.call(xml))[formatted_time]["open_all_day"]).to eq false
         expect(JSON.parse(service.call(xml))[formatted_time]["closes_at_night"]).to eq true
       end


### PR DESCRIPTION
Fixes #36 

This maps over the child nodes of hours and allows us to keep track of dates without hours.

[[1:00, 2:00],[1:00, 2:00],[1:00, 2:00],[1:00, 2:00],[],[1:00, 2:00]]