### PR TITLE
updated error handlers to send to logs

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -8,11 +8,11 @@ class WidgetsController < ApplicationController
       @hours = '{}'
       @layout = 'calendar_widget'
     elsif @template == 'special_hours'
-      @hours = alma_special_hours_request
+      @hours = alma_special_hours_request || '{}'
     elsif @template == 'todays_hours'
-      @hours = alma_todays_hours_request
+      @hours = alma_todays_hours_request || '{}'
     else
-      @hours = alma_request
+      @hours = alma_request || '{}'
     end
 
     respond_to do |format|

--- a/app/models/alma_hours.rb
+++ b/app/models/alma_hours.rb
@@ -3,7 +3,7 @@ require 'cgi'
 
 class AlmaHours
   def self.fetch(date_from, date_to, url, apikey, cached_for)
-    logger = Logger.new(STDOUT)
+    logger = Rails.logger
     begin
       headers  = { CGI::escape('from') => date_from, CGI::escape('to') => date_to, CGI::escape('apikey') => apikey }
       url = "#{url}?#{headers.to_query}"

--- a/app/models/alma_hours.rb
+++ b/app/models/alma_hours.rb
@@ -3,16 +3,18 @@ require 'cgi'
 
 class AlmaHours
   def self.fetch(date_from, date_to, url, apikey, cached_for)
-
+    logger = Logger.new(STDOUT)
     begin
       headers  = { CGI::escape('from') => date_from, CGI::escape('to') => date_to, CGI::escape('apikey') => apikey }
       url = "#{url}?#{headers.to_query}"
-      Rails.cache.fetch("#{date_from}#{date_to}#{url}/AlmaOpenHours/fetch", expires_in: cached_for) { open(url).read }
 
+      Rails.cache.fetch("#{date_from}#{date_to}#{url}/AlmaOpenHours/fetch", expires_in: cached_for) { open(url).read }
     rescue ArgumentError
-      raise BadRequest.new(), "Invalid date requested, must use format YYYY-MM-dd"
+      logger.error("ArgumentError: invalid date requested, must use format YYYY-MM-dd")
+      return nil
     rescue StandardError => e
-      raise e
+      logger.error("StandardError: #{e.message}")
+      return nil
     end
   end
 end

--- a/app/models/alma_special_hours.rb
+++ b/app/models/alma_special_hours.rb
@@ -18,13 +18,15 @@ class AlmaSpecialHours
   # Fetch the Alma Special Hours xml document for the date specified
   # @return [XML::Document]
   def fetch_dates
+    logger = Logger.new(STDOUT)
     begin
       Rails.cache.fetch("#{special_hours_url}/AlmaSpecialHours/fetch", expires_in: cached_for) { open(special_hours_url).read }
-
     rescue ArgumentError
-      raise BadRequest.new(), "Invalid request"
+      logger.error("ArgumentError: invalid request")
+      return nil
     rescue StandardError => e
-      raise e
+      logger.error("StandardError: #{e.message}")
+      return nil
     end
   end
 

--- a/app/models/alma_special_hours.rb
+++ b/app/models/alma_special_hours.rb
@@ -18,7 +18,7 @@ class AlmaSpecialHours
   # Fetch the Alma Special Hours xml document for the date specified
   # @return [XML::Document]
   def fetch_dates
-    logger = Logger.new(STDOUT)
+    logger = Rails.logger
     begin
       Rails.cache.fetch("#{special_hours_url}/AlmaSpecialHours/fetch", expires_in: cached_for) { open(special_hours_url).read }
     rescue ArgumentError

--- a/app/views/layouts/calendar_widget.html.erb
+++ b/app/views/layouts/calendar_widget.html.erb
@@ -8,6 +8,10 @@
     <style> body {font-family: 'Open sans',sans-serif;} </style>
     <script>
         $( function() {
+            function isEmpty(obj) {
+                for (var x in obj) { return false; }
+                return true;
+            }
             function showHours(dateText) {
                 var ajaxUrl = '<%= Rails.application.config.action_mailer.default_url_options[:protocol] %>://<%= Rails.application.config.action_mailer.default_url_options[:host] %>/hours'
                 $.ajax({
@@ -18,13 +22,16 @@
                     },
                     dataType: 'json',
                     success: function (data) {
-                        if (data) {
+                        $('.ajax_output').remove();
+                        if (isEmpty(data) == true) {
+                            $('#libHours').prepend('<div class=\"ajax_output\"><p><%= I18n.t 'no_hours_available' %></p></div>');
+                        } else {
+
                             var items = [];
                             $.each( data, function( key, val ) {
                                 items.push( "<b>" + val.string_date + "</b><br>" + val.formatted_hours + "<br>" + val.event_desc );
                             });
 
-                            $('.ajax_output').remove();
                             $('#libHours').prepend('<div class=\"ajax_output\"><p>' + items.join("") +'</p></div>');
 
                         }

--- a/app/views/widgets/hours/special_hours.html.erb
+++ b/app/views/widgets/hours/special_hours.html.erb
@@ -1,4 +1,7 @@
 <div class="special_dates">
+  <% if hours.blank? %>
+    <strong><%= I18n.t 'no_hours_available' %></strong>
+  <% end %>
   <ul>
     <% hours.each do |key, value| %>
       <li>

--- a/app/views/widgets/hours/this_weeks_hours.html.erb
+++ b/app/views/widgets/hours/this_weeks_hours.html.erb
@@ -1,5 +1,8 @@
 <div class="this_weeks_hours">
   <p>
+    <% if hours.blank? %>
+      <strong><%= I18n.t 'no_hours_available' %></strong>
+    <% end %>
     <% hours.each do |key, value| %>
       <% day = Date.parse(key) %>
       <strong><%= day.today? ? 'Today' : day.strftime("%A") %>:</strong>

--- a/app/views/widgets/hours/todays_hours.html.erb
+++ b/app/views/widgets/hours/todays_hours.html.erb
@@ -1,4 +1,7 @@
 <div class="todays_hours">
+  <% if hours.blank? %>
+    <h2><%= I18n.t 'no_hours_available' %></h2>
+  <% end %>
   <% hours.each do |key, value| %>
     <% day = Date.parse(key) %>
     <h2><%= day.today? ? 'Today' : day.strftime("%A") %>:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+  no_hours_available: "No hours available."

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -52,5 +52,17 @@ describe ApiController, type: :controller do
         expect(assigns(:hours)["valid_json_with_data"]["data"]).to eq "data"
       end
     end
+
+    context "When a day is provided and no hours are available" do
+      before do
+        allow(alma).to receive(:xml_document).and_return(nil)
+        allow(API::HoursXmlToJsonParser).to receive(:call).with(anything(), dates).and_return(nil)
+      end
+
+      it "responds to json" do
+        post :hours
+        expect(assigns(:hours)).to be_nil
+      end
+    end
   end
 end

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -36,5 +36,25 @@ RSpec.describe WidgetsController, type: :controller do
         expect(response.body).to include("widget_datepicker")
       end
     end
+
+    context "when no hours are available" do
+      before do
+        allow(subject).to receive(:alma_request).and_return(nil)
+        allow(API::HoursXmlToJsonParser).to receive(:call).with(valid_xml, dates).and_return(nil)
+        allow_any_instance_of(Alma).to receive(:xml_document).and_return(nil)
+        allow_any_instance_of(Alma).to receive(:fetch).and_return(nil)
+      end
+
+      it "returns no hours available when rendering inline js" do
+        post :hours, params: { template: 'this_weeks_hours', format: :js }
+        expect(response.body).to include("No hours available.")
+      end
+
+      it "returns no hours available when rendering html" do
+        get :hours, params: { template: 'calendar', format: :html }
+        expect(response.body).to include("No hours available.")
+      end
+
+    end
   end
 end


### PR DESCRIPTION
- updated `alma_hours` and `alma_special_hours` models to send any server-side errors to the logs and return nil
- updated widgets to print a message `No hours available.` (this text can be updated at `config/locales/en.yml`) when alma fails to return data due to exemptions

closes #56 