### PR TITLE
update loofah to 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'capistrano-passenger'
 gem "capistrano-rails", require: false
 gem 'capistrano-rbenv'
 gem 'capistrano3-puma'
-gem "loofah", ">= 2.2.3"
+gem "loofah", ">= 2.3.1"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.8.0)
     ffi (1.9.25)
@@ -95,7 +95,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.3)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -113,7 +113,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
     nio4r (2.3.1)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     public_suffix (3.0.2)
     puma (3.11.4)
@@ -220,7 +220,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-puma
   listen (>= 3.0.5, < 3.2)
-  loofah (>= 2.2.3)
+  loofah (>= 2.3.1)
   mysql2
   puma (~> 3.11)
   rails (~> 5.2.0)


### PR DESCRIPTION
Update to address GitHub security alert:
```
CVE-2019-15587
low severity
Vulnerable versions: < 2.3.1
Patched version: 2.3.1
In the Loofah gem for Ruby through v2.3.0 unsanitized JavaScript may occur in sanitized output when a crafted SVG element is republished.
```